### PR TITLE
Use Django models to store state

### DIFF
--- a/data/etc/plinth/plinth.config
+++ b/data/etc/plinth/plinth.config
@@ -13,7 +13,7 @@ actions_dir = /usr/share/plinth/actions
 doc_dir = /usr/share/doc/plinth
 
 # file locations
-store_file = %(data_dir)s/store.sqlite3
+store_file = %(data_dir)s/plinth.sqlite3
 status_log_file = %(log_dir)s/status.log
 access_log_file = %(log_dir)s/access.log
 pidfile = %(pid_dir)s/plinth.pid

--- a/plinth.config
+++ b/plinth.config
@@ -13,7 +13,7 @@ actions_dir = %(file_root)s/actions
 doc_dir = %(file_root)s/doc
 
 # file locations
-store_file = %(data_dir)s/store.sqlite3
+store_file = %(data_dir)s/plinth.sqlite3
 status_log_file = %(log_dir)s/status.log
 access_log_file = %(log_dir)s/access.log
 pidfile = %(pid_dir)s/plinth.pid

--- a/plinth/__main__.py
+++ b/plinth/__main__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 import argparse
 import django.conf
@@ -160,8 +160,6 @@ def configure_django():
             }
         }
 
-    data_file = os.path.join(cfg.data_dir, 'plinth.sqlite3')
-
     template_directories = module_loader.get_template_directories()
     sessions_directory = os.path.join(cfg.data_dir, 'sessions')
     django.conf.settings.configure(
@@ -170,12 +168,13 @@ def configure_django():
                 {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}},
         DATABASES={'default':
                    {'ENGINE': 'django.db.backends.sqlite3',
-                    'NAME': data_file}},
+                    'NAME': cfg.store_file}},
         DEBUG=cfg.debug,
         INSTALLED_APPS=['bootstrapform',
                         'django.contrib.auth',
                         'django.contrib.contenttypes',
-                        'django.contrib.messages'],
+                        'django.contrib.messages',
+                        'plinth'],
         LOGGING=logging_configuration,
         LOGIN_URL='lib:login',
         LOGIN_REDIRECT_URL='apps:index',
@@ -199,10 +198,9 @@ def configure_django():
     LOGGER.info('Configured Django')
     LOGGER.info('Template directories - %s', template_directories)
 
-    if not os.path.isfile(data_file):
-        LOGGER.info('Creating and initializing data file')
-        django.core.management.call_command('syncdb', interactive=False)
-        os.chmod(data_file, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP)
+    LOGGER.info('Creating or adding new tables to data file')
+    django.core.management.call_command('syncdb', interactive=False)
+    os.chmod(cfg.store_file, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP)
 
 
 def main():

--- a/plinth/cfg.py
+++ b/plinth/cfg.py
@@ -70,7 +70,3 @@ def read():
 
     global port  # pylint: disable-msg=W0603
     port = int(port)
-
-    global store_file  # pylint: disable-msg=W0603
-    if store_file.endswith(".sqlite3"):
-        store_file = os.path.splitext(store_file)[0]

--- a/plinth/kvstore.py
+++ b/plinth/kvstore.py
@@ -1,0 +1,42 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Simple key/value store using Django models
+"""
+
+from plinth.models import KVStore
+
+
+def get(key):
+    """Return the value of a key"""
+    # pylint: disable-msg=E1101
+    return KVStore.objects.get(pk=key).value
+
+
+def get_default(key, default_value):
+    """Return the value of the key if key exists else return default_value"""
+    try:
+        return get(key)
+    except Exception:
+        return default_value
+
+
+def set(key, value):  # pylint: disable-msg=W0622
+    """Store the value of a key"""
+    store = KVStore(key=key, value=value)
+    store.save()

--- a/plinth/models.py
+++ b/plinth/models.py
@@ -1,0 +1,39 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Django models for the main application
+"""
+
+from django.db import models
+import json
+
+
+class KVStore(models.Model):
+    """Model to store retrieve key/value configuration"""
+    key = models.TextField(primary_key=True)
+    value_json = models.TextField()
+
+    @property
+    def value(self):
+        """Return the JSON decoded value of the key/value pair"""
+        return json.loads(self.value_json)
+
+    @value.setter
+    def value(self, val):
+        """Store the value of the key/value pair by JSON encoding it"""
+        self.value_json = json.dumps(val)


### PR DESCRIPTION
- Remove dependency on withsqlite and use Django models.
  This avoids depending on a module that is not available in PyPi.
  Withsqlite does not have Python3 support. It does not work when
  we choose a different database backend. Atleast partly duplicates
  what Django models are meant for. 
- Check and update database schema on every run so that
  newly added modules can add tables and old ones can update.

@NickDaly, @jvalleroy, @petterreinholdtsen, @fonfon, Please review the merge request if any of you find time.
