### PR TITLE
Update module-manager to use enabled folder with regular files.

### DIFF
--- a/actions/module-manager
+++ b/actions/module-manager
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Usage:
 #   module-manager list-available
@@ -6,54 +6,60 @@
 #   module-manager enable <python_root> <module_name>
 #   module-manager disable <python_root> <module_name>
 
-# associate array with mapping between module names and install paths 
-# (relative to <python_root>/modules/)
-declare -A modules=( ["owncloud"]="installed/apps/owncloud.py" )
+# list of modules that may be enabled/disabled
+modules="owncloud"
 
 case "$1" in
 "list-available")
     # TODO: Replace this with something like "aptitude search -F %p plinth-"
-    echo "${!modules[@]}"
+    echo "$modules"
     ;;
 
 "list-enabled")
     # TODO: Replace this with something like 'aptitude search -F %p | grep "plinth-"'
-    for module in "${!modules[@]}"
-    do 
-        if [ -e "$2"/modules/"$module".py ] ; then
-	    echo "$module"
+    for module in "$modules"
+    do
+        if [ -e "$2"/modules/enabled/"$module" ] ; then
+            echo "$module"
         fi
     done
     ;;
 
 "enable")
     # TODO: Replace this with "aptitude install plinth-<module>"
-    for module in "${!modules[@]}"
+    for module in "$modules"
     do
-        if [ "$3" == "$module" ] ; then
-	    if [ ! -e "$2"/modules/"$3".py ] ; then
-	        ln -s "$2"/modules/"${modules["$3"]}" "$2"/modules/"$3".py
-	        RETVAL=$?
-	        [ $RETVAL -eq 0 ] && echo "enabled" "$3"
-	        [ $RETVAL -ne 0 ] && echo "failed to enable" "$3"
-	    fi
+        if [ "$3" = "$module" ] ; then
+            if [ ! -e "$2"/modules/enabled/"$3" ] ; then
+                touch "$2"/modules/enabled/"$3"
+                RETVAL=$?
+                if [ $RETVAL -eq 0 ] ; then
+		    echo "enabled" "$3"
+		else
+                    echo "failed to enable" "$3"
+		fi
+		exit $RETVAL
+            fi
         fi
     done
     ;;
 
 "disable")
     # TODO: Replace this with "aptitude purge plinth-<module>"
-    for module in "${!modules[@]}"
+    for module in "$modules"
     do
-        if [ "$3" == "$module" ] ; then
-	    if [ -e "$2"/modules/"$3".py ] ; then
-	        rm -f "$2"/modules/"$3".py
-	        RETVAL=$?
-	        [ $RETVAL -eq 0 ] && echo "disabled" "$3"
-	        [ $RETVAL -ne 0 ] && echo "failed to disable" "$3"
-	    fi
+        if [ "$3" = "$module" ] ; then
+            if [ -e "$2"/modules/enabled/"$3" ] ; then
+                rm -f "$2"/modules/enabled/"$3"
+                RETVAL=$?
+                if [ $RETVAL -eq 0 ] ; then
+		    echo "disabled" "$3"
+		else
+                    echo "failed to disable" "$3"
+		fi
+		exit $RETVAL
+            fi
         fi
     done
     ;;
 esac
-

--- a/plinth/modules/packages/packages.py
+++ b/plinth/modules/packages/packages.py
@@ -3,6 +3,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.template.response import TemplateResponse
 from gettext import gettext as _
+import os
 
 from plinth import actions
 from plinth import cfg
@@ -16,7 +17,9 @@ def get_modules_available():
 
 def get_modules_enabled():
     """Return list of all modules"""
-    output = actions.run('module-manager', ['list-enabled'])
+    root = os.path.join(os.path.dirname(__file__), '..', '..')
+    output = actions.run('module-manager',
+                         ['list-enabled', root])
     return output.split()
 
 


### PR DESCRIPTION
Update module-manager as follows:
1. Using regular files instead of symlinks.
2. Enabled modules are listed under modules/enabled.
3. Fixed an issue where module-manager would return the wrong exit code.
4. Fixed an issue where the list-enabled command was being run without the required parameter.
