### PR TITLE
repro improvements

### DIFF
--- a/actions/repro
+++ b/actions/repro
@@ -20,6 +20,9 @@
 Configuration helper for repro SIP proxy.
 """
 
+import time
+from urllib import request, error
+
 import argparse
 import augeas
 
@@ -34,12 +37,20 @@ def parse_arguments():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest='subcommand', help='Sub command')
 
-    subparsers.add_parser('setup', help='Configure repro')
+    setup = subparsers.add_parser('setup', help='Configure repro')
+    setup.add_argument('--domain', help='Domain name')
+
+    add_domain = subparsers.add_parser('add-domain', help='Add domain name')
+    add_domain.add_argument('--domain', help='Domain name')
+
+    remove_domain = subparsers.add_parser('remove-domain',
+                                          help='Remove domain name')
+    remove_domain.add_argument('--domain', help='Domain name')
 
     return parser.parse_args()
 
 
-def subcommand_setup(_):
+def subcommand_setup(arguments):
     """Configure repro."""
     aug = load_augeas()
 
@@ -53,6 +64,43 @@ def subcommand_setup(_):
     action_utils.service_restart('repro')
     action_utils.webserver_enable('repro-plinth')
 
+    if arguments.domain:
+        while 1:
+            tries = 0
+            try:
+                _add_domain(arguments.domain, restart=False)
+                break
+            except error.URLError:
+                tries += 1
+                if tries >= 30:
+                    return
+                time.sleep(2)
+
+    action_utils.service_restart('repro')
+
+
+def subcommand_add_domain(arguments):
+    """Add domain name."""
+    _add_domain(arguments.domain)
+
+
+def _add_domain(domain, restart=True):
+    """Add domain name."""
+    request.urlopen(
+        'http://localhost:5080/domains.html?domainUri=' + domain \
+        + '&action=Add')
+
+    if restart:
+        action_utils.service_restart('repro')
+
+
+def subcommand_remove_domain(arguments):
+    """Remove domain name."""
+    request.urlopen(
+        'http://localhost:5080/domains.html?action=Remove&remove.' \
+        + arguments.domain + '=on')
+
+    action_utils.service_restart('repro')
 
 
 def load_augeas():

--- a/actions/repro
+++ b/actions/repro
@@ -21,10 +21,12 @@ Configuration helper for repro SIP proxy.
 """
 
 import argparse
+import augeas
 
 from plinth import action_utils
 
 CONFIG = '/etc/repro/repro.config'
+AUG_PATH = '/files' + CONFIG + '/.anon/'
 
 
 def parse_arguments():
@@ -39,24 +41,28 @@ def parse_arguments():
 
 def subcommand_setup(_):
     """Configure repro."""
-    with open(CONFIG, 'r') as conf:
-        lines = conf.readlines()
+    aug = load_augeas()
 
-    with open(CONFIG, 'w') as conf:
-        for line in lines:
-            if line.startswith('Database1Path'):
-                # workaround for Debian bug #803113
-                conf.write('Database1Path = /var/lib/repro\n')
-            elif line.startswith('TLSPort'):
-                conf.write('TLSPort = 5061\n')
-            elif line.startswith('DisableHttpAuth'):
-                # let apache handle authentication
-                conf.write('DisableHttpAuth = true\n')
-            else:
-                conf.write(line)
+    # workaround for Debian bug #803113
+    aug.set(AUG_PATH + 'Database1Path', '/var/lib/repro')
+    aug.set(AUG_PATH + 'TLSPort', '5061')
+    # let apache handle authentication
+    aug.set(AUG_PATH + 'DisableHttpAuth', 'true')
+    aug.save()
 
     action_utils.service_restart('repro')
     action_utils.webserver_enable('repro-plinth')
+
+
+
+def load_augeas():
+    """Initialize Augeas."""
+    aug = augeas.Augeas(flags=augeas.Augeas.NO_LOAD +
+                        augeas.Augeas.NO_MODL_AUTOLOAD)
+    aug.set('/augeas/load/Php/lens', 'Php.lns')
+    aug.set('/augeas/load/Php/incl[last() + 1]', CONFIG)
+    aug.load()
+    return aug
 
 
 def main():

--- a/actions/repro
+++ b/actions/repro
@@ -20,6 +20,8 @@
 Configuration helper for repro SIP proxy.
 """
 
+import os
+import sys
 import time
 from urllib import request, error
 
@@ -30,6 +32,15 @@ from plinth import action_utils
 
 CONFIG = '/etc/repro/repro.config'
 AUG_PATH = '/files' + CONFIG + '/.anon/'
+CERT_DIR = '/etc/letsencrypt/live'
+
+
+class MissingCertificateError(Exception):
+    """
+    Exception raised when LetsEncrypt certificate for given domain could not
+    be found.
+    """
+    pass
 
 
 def parse_arguments():
@@ -46,6 +57,17 @@ def parse_arguments():
     remove_domain = subparsers.add_parser('remove-domain',
                                           help='Remove domain name')
     remove_domain.add_argument('--domain', help='Domain name')
+
+    add_letsencrypt = subparsers.add_parser(
+        'add-letsencrypt',
+        help='Start using LetsEncrypt certificate')
+    add_letsencrypt.add_argument('--domain', help='Domain name')
+
+    drop_letsencrypt = subparsers.add_parser(
+        'drop-letsencrypt',
+        help='Stop using LetsEncrypt certificate, if it matches configured '
+        'domain')
+    drop_letsencrypt.add_argument('--domain', help='Domain name')
 
     return parser.parse_args()
 
@@ -75,8 +97,12 @@ def subcommand_setup(arguments):
                 if tries >= 30:
                     return
                 time.sleep(2)
+        try:
+            _add_letsencrypt(arguments.domain, restart=False)
+        except MissingCertificateError:
+            pass
 
-    action_utils.service_restart('repro')
+        action_utils.service_restart('repro')
 
 
 def subcommand_add_domain(arguments):
@@ -101,6 +127,55 @@ def subcommand_remove_domain(arguments):
         + arguments.domain + '=on')
 
     action_utils.service_restart('repro')
+
+
+def subcommand_add_letsencrypt(arguments):
+    """Start using letsencrypt certificate."""
+    try:
+        _add_letsencrypt(arguments.domain)
+    except MissingCertificateError as err:
+        print(str(err), file=sys.stderr)
+        sys.exit(1)
+
+
+def _add_letsencrypt(domain, restart=True):
+    """Start using letsencrypt certificate."""
+    cert_file = os.path.join(CERT_DIR, domain, 'fullchain.pem')
+    key_file = os.path.join(CERT_DIR, domain, 'privkey.pem')
+
+    if os.path.isfile(cert_file) and os.path.isfile(key_file):
+        # XXX: Should use augeas here, but it doesn't always leave a
+        # space after the = separator, and repro doesn't like that.
+        with open('/etc/repro/repro.config', 'r') as conffile:
+            lines = conffile.readlines()
+        with open('/etc/repro/repro.config', 'w') as conffile:
+            for line in lines:
+                if line.startswith('TLSDomainName ='):
+                    conffile.write('TLSDomainName = {0}\n'.format(domain))
+                elif line.startswith('TLSCertificate ='):
+                    conffile.write('TLSCertificate = {0}\n'.format(cert_file))
+                elif line.startswith('TLSPrivateKey ='):
+                    conffile.write('TLSPrivateKey = {0}\n'.format(key_file))
+                else:
+                    conffile.write(line)
+
+        if restart:
+            action_utils.service_restart('repro')
+    else:
+        raise MissingCertificateError(
+            'Could not find certificate for domain:', domain)
+
+
+def subcommand_drop_letsencrypt(arguments):
+    """Stop using letsencrypt certificate, if it matches configured domain."""
+    aug = load_augeas()
+    if aug.get(AUG_PATH + 'TLSDomainName') == arguments.domain:
+        aug.set(AUG_PATH + 'TLSDomainName', None)
+        aug.set(AUG_PATH + 'TLSCertificate', None)
+        aug.set(AUG_PATH + 'TLSPrivateKey', None)
+        aug.save()
+
+        action_utils.service_restart('repro')
 
 
 def load_augeas():

--- a/plinth/modules/letsencrypt/views.py
+++ b/plinth/modules/letsencrypt/views.py
@@ -32,6 +32,7 @@ from plinth import actions
 from plinth.errors import ActionError
 from plinth.modules import letsencrypt
 from plinth.modules import names
+from plinth.signals import letsencrypt_cert_obtained, letsencrypt_cert_revoked
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +55,8 @@ def revoke(request, domain):
         messages.success(
             request, _('Certificate successfully revoked for domain {domain}')
             .format(domain=domain))
+        letsencrypt_cert_revoked.send_robust(
+            sender='letsencrypt', domain=domain)
     except ActionError as exception:
         messages.error(
             request,
@@ -71,6 +74,8 @@ def obtain(request, domain):
         messages.success(
             request, _('Certificate successfully obtained for domain {domain}')
             .format(domain=domain))
+        letsencrypt_cert_obtained.send_robust(
+            sender='letsencrypt', domain=domain)
     except ActionError as exception:
         messages.error(
             request,

--- a/plinth/signals.py
+++ b/plinth/signals.py
@@ -31,3 +31,5 @@ domainname_change = Signal(providing_args=['old_domainname', 'new_domainname'])
 domain_added = Signal(providing_args=['domain_type', 'name', 'description',
                                       'services'])
 domain_removed = Signal(providing_args=['domain_type', 'name'])
+letsencrypt_cert_obtained = Signal(providing_args=['domain'])
+letsencrypt_cert_revoked = Signal(providing_args=['domain'])


### PR DESCRIPTION
- Use augeas to modify config with Php lens.
  - (I didn't find a way to make this work for the LetsEncrypt configuration though.)
- Add new domain name (and remove old domain name) automatically, using admin web panel.
- Use any new LetsEncrypt certificate that matches the current domain name. Stop using when revoked.
- Also setup domain and LE cert during module setup, if available.
  - It may be a few seconds before the admin web panel is available, so wait and retry.
