### PR TITLE
Add Mesh VPN (tinc) module

### DIFF
--- a/actions/tinc
+++ b/actions/tinc
@@ -80,6 +80,11 @@ def subcommand_setup(arguments):
                             stdin=subprocess.PIPE, shell=False)
     proc.communicate(input=b'y\ny\n')
 
+    with open('/etc/tinc/freedombox/tinc-up', 'w') as up_script:
+        up_script.write(
+            'ifconfig $INTERFACE ' + arguments.ip + ' netmask 255.255.0.0\n')
+    os.chmod('/etc/tinc/freedombox/tinc-up', 0o755)
+
     action_utils.service_enable('tinc@freedombox')
     action_utils.service_start('tinc@freedombox')
 
@@ -87,6 +92,19 @@ def subcommand_setup(arguments):
 def subcommand_load(arguments):
     """Load VPN configuration package."""
     shutil.unpack_archive(arguments.package, '/etc/tinc/freedombox')
+
+    # Try to connect to all configured hosts.
+    aug = load_augeas()
+    name = aug.get('/files' + CONFIG_FILE + '/Name')
+
+    aug.remove('/files' + CONFIG_FILE + '/ConnectTo')
+
+    for host in list(os.walk('/etc/tinc/freedombox/hosts'))[0][2]:
+        if host != name:
+            aug.set('/files' + CONFIG_FILE + '/ConnectTo[last() + 1]', host)
+
+    aug.save()
+
     action_utils.service_restart('tinc@freedombox')
 
 

--- a/actions/tinc
+++ b/actions/tinc
@@ -1,0 +1,104 @@
+#!/usr/bin/python3
+# -*- mode: python -*-
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Configuration helper for tinc.
+"""
+
+import os
+import subprocess
+
+import argparse
+import augeas
+
+from plinth import action_utils
+
+CONFIG_FILE = '/etc/tinc/freedombox/tinc.conf'
+
+
+def parse_arguments():
+    """Return parsed command line arguments as dictionary."""
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest='subcommand', help='Sub command')
+
+    subparsers.add_parser('is-setup', help='Return whether setup is complete')
+
+    setup = subparsers.add_parser('setup',
+                                  help='Perform initial configuration')
+    setup.add_argument('--name', help='Your hostname on the VPN')
+    setup.add_argument('--ip',
+                       help='Your new IP address on the VPN. It should begin '
+                       'with 10. or 198.162. or 17.16.')
+    setup.add_argument('--address', default=None,
+                       help='Optional, an IP address or domain name where '
+                       'your tinc can be accessed (over the public Internet)')
+
+    return parser.parse_args()
+
+
+def subcommand_is_setup(_):
+    """Return whether setup is complete."""
+    print('true' if os.path.isfile(CONFIG_FILE) else 'false')
+
+
+def subcommand_setup(arguments):
+    """Perform initial configuration."""
+    os.makedirs('/etc/tinc/freedombox/hosts', exist_ok=True)
+
+    aug = load_augeas()
+    aug.set('/files' + CONFIG_FILE + '/Name', arguments.name)
+    aug.save()
+
+    host_file = '/etc/tinc/freedombox/hosts/' + arguments.name
+    with open(host_file, 'w') as host:
+        host.write('Subnet = {0}/32\n'.format(arguments.ip))
+        if arguments.address:
+            host.write('Address = {0}\n'.format(arguments.address))
+
+    proc = subprocess.Popen(['tincd', '--net=freedombox', '--generate-keys'],
+                            stdin=subprocess.PIPE, shell=False)
+    proc.communicate(input=b'y\ny\n')
+
+    action_utils.service_enable('tinc@freedombox')
+    action_utils.service_start('tinc@freedombox')
+
+
+def load_augeas():
+    """Initialize Augeas."""
+    aug = augeas.Augeas(flags=augeas.Augeas.NO_LOAD +
+                        augeas.Augeas.NO_MODL_AUTOLOAD)
+
+    aug.set('/augeas/load/Shellvars/lens', 'Shellvars.lns')
+    aug.set('/augeas/load/Shellvars/incl[last() + 1]', CONFIG_FILE)
+
+    aug.load()
+    return aug
+
+
+def main():
+    """Parse arguments and perform all duties."""
+    arguments = parse_arguments()
+
+    subcommand = arguments.subcommand.replace('-', '_')
+    subcommand_method = globals()['subcommand_' + subcommand]
+    subcommand_method(arguments)
+
+
+if __name__ == '__main__':
+    main()

--- a/actions/tinc
+++ b/actions/tinc
@@ -22,6 +22,7 @@ Configuration helper for tinc.
 """
 
 import os
+import shutil
 import subprocess
 
 import argparse
@@ -48,6 +49,10 @@ def parse_arguments():
     setup.add_argument('--address', default=None,
                        help='Optional, an IP address or domain name where '
                        'your tinc can be accessed (over the public Internet)')
+
+    load = subparsers.add_parser('load',
+                                 help='Load VPN configuration package')
+    load.add_argument('--package', help='Path to package archive file')
 
     return parser.parse_args()
 
@@ -77,6 +82,12 @@ def subcommand_setup(arguments):
 
     action_utils.service_enable('tinc@freedombox')
     action_utils.service_start('tinc@freedombox')
+
+
+def subcommand_load(arguments):
+    """Load VPN configuration package."""
+    shutil.unpack_archive(arguments.package, '/etc/tinc/freedombox')
+    action_utils.service_restart('tinc@freedombox')
 
 
 def load_augeas():

--- a/data/etc/plinth/modules-enabled/tinc
+++ b/data/etc/plinth/modules-enabled/tinc
@@ -1,0 +1,1 @@
+plinth.modules.tinc

--- a/plinth/modules/tinc/__init__.py
+++ b/plinth/modules/tinc/__init__.py
@@ -1,0 +1,84 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Plinth module to configure tinc.
+"""
+
+from django.utils.translation import ugettext_lazy as _
+
+from plinth import actions
+from plinth import action_utils
+from plinth import cfg
+from plinth import service as service_module
+
+
+version = 1
+
+depends = ['apps']
+
+service = None
+
+managed_services = ['tinc@freedombox']
+
+managed_packages = ['tinc']
+
+title = _('Mesh VPN (tinc)')
+
+description = [
+    _('tinc is a Virtual Private Network (VPN). It uses tunnelling and '
+      'encryption to create a secure private network between hosts on the '
+      'Internet.'),
+
+    _('tinc differs from traditional VPNs in that it uses a mesh network '
+      'architecture, instead of a client-server model. In other words, any '
+      'host can act as either client or server as needed.'),
+]
+
+
+def init():
+    """Initialize the tinc module."""
+    menu = cfg.main_menu.get('apps:index')
+    menu.add_urlname(title, 'glyphicon-link', 'tinc:index')
+
+    global service
+    service = service_module.Service(
+        managed_services[0], title, ports=['tinc'], is_external=True)
+
+
+def setup(helper, old_version=None):
+    """Install and configure the module."""
+    helper.install(managed_packages)
+    helper.call('post', service.notify_enabled, None, True)
+
+
+def is_setup():
+    """Return whether tinc setup has been completed."""
+    return actions.superuser_run('tinc', ['is-setup']).strip() == 'true'
+
+
+def diagnose():
+    """Run diagnostics and return the results."""
+    results = []
+
+    results.append(action_utils.diagnose_port_listening(655, 'tcp4'))
+    results.append(action_utils.diagnose_port_listening(655, 'tcp6'))
+
+    results.append(action_utils.diagnose_port_listening(655, 'udp4'))
+    results.append(action_utils.diagnose_port_listening(655, 'udp6'))
+
+    return results

--- a/plinth/modules/tinc/forms.py
+++ b/plinth/modules/tinc/forms.py
@@ -25,8 +25,6 @@ from django.utils.translation import ugettext_lazy as _
 
 from plinth.modules.config.config import domain_label_validator
 
-NAME_REGEX = r'^[a-zA-Z0-9]{,63}$'
-
 
 class TincSetupForm(forms.Form):
     """Form to complete tinc setup."""
@@ -35,7 +33,7 @@ class TincSetupForm(forms.Form):
         help_text=_('Your hostname on the VPN'),
         validators=[
             validators.RegexValidator(
-                NAME_REGEX,
+                r'^[a-zA-Z0-9]{,63}$',
                 _('Invalid name'))])
 
     ip_address = forms.CharField(

--- a/plinth/modules/tinc/forms.py
+++ b/plinth/modules/tinc/forms.py
@@ -46,3 +46,10 @@ class TincForm(forms.Form):
     enabled = forms.BooleanField(
         label=_('Enable tinc'),
         required=False)
+
+
+class TincLoadForm(forms.Form):
+    """Form to load VPN configuration package."""
+    package = forms.FileField(
+        label=_('Package'),
+        help_text=_('The package file is typically a .tar.gz archive.'))

--- a/plinth/modules/tinc/forms.py
+++ b/plinth/modules/tinc/forms.py
@@ -20,25 +20,40 @@ Forms for the tinc module.
 """
 
 from django import forms
+from django.core import validators
 from django.utils.translation import ugettext_lazy as _
+
+from plinth.modules.config.config import domain_label_validator
+
+NAME_REGEX = r'^[a-zA-Z0-9]{,63}$'
 
 
 class TincSetupForm(forms.Form):
     """Form to complete tinc setup."""
     name = forms.CharField(
         label=_('Name'),
-        help_text=_('Your hostname on the VPN'))
+        help_text=_('Your hostname on the VPN'),
+        validators=[
+            validators.RegexValidator(
+                NAME_REGEX,
+                _('Invalid name'))])
 
-    ip = forms.CharField(
+    ip_address = forms.CharField(
         label=_('IP Address'),
         help_text=_('Your new IP address on the VPN. It should begin with '
-                    '10. or 198.162. or 17.16.'))
+                    '10. or 198.162. or 17.16.'),
+        validators=[validators.validate_ipv46_address])
 
     address = forms.CharField(
         label=_('Address'),
         required=False,
         help_text=_('Optional, an IP address or domain name where your tinc '
-                    'can be accessed (over the public Internet)'))
+                    'can be accessed (over the public Internet)'),
+        validators=[
+            validators.RegexValidator(
+                r'^[a-zA-Z0-9]([-a-zA-Z0-9.]{,251}[a-zA-Z0-9])?$',
+                _('Invalid address')),
+            domain_label_validator])
 
 
 class TincForm(forms.Form):

--- a/plinth/modules/tinc/forms.py
+++ b/plinth/modules/tinc/forms.py
@@ -1,0 +1,48 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Forms for the tinc module.
+"""
+
+from django import forms
+from django.utils.translation import ugettext_lazy as _
+
+
+class TincSetupForm(forms.Form):
+    """Form to complete tinc setup."""
+    name = forms.CharField(
+        label=_('Name'),
+        help_text=_('Your hostname on the VPN'))
+
+    ip = forms.CharField(
+        label=_('IP Address'),
+        help_text=_('Your new IP address on the VPN. It should begin with '
+                    '10. or 198.162. or 17.16.'))
+
+    address = forms.CharField(
+        label=_('Address'),
+        required=False,
+        help_text=_('Optional, an IP address or domain name where your tinc '
+                    'can be accessed (over the public Internet)'))
+
+
+class TincForm(forms.Form):
+    """Form to configure tinc after setup."""
+    enabled = forms.BooleanField(
+        label=_('Enable tinc'),
+        required=False)

--- a/plinth/modules/tinc/templates/tinc.html
+++ b/plinth/modules/tinc/templates/tinc.html
@@ -41,6 +41,16 @@
              value="{% trans "Download package" %}"/>
   </form>
 
+  <br><p>
+    {% blocktrans trimmed %}
+      If you have received a package for an existing tinc VPN, you can load
+      it to join the VPN.
+    {% endblocktrans %}
+  <p>
+    <a class="btn btn-default" href="{% url 'tinc:load' %}">
+      {% trans "Load package &raquo;" %}</a>
+  </p>
+
 
   <h3>{% trans "Status" %}</h3>
 

--- a/plinth/modules/tinc/templates/tinc.html
+++ b/plinth/modules/tinc/templates/tinc.html
@@ -24,6 +24,24 @@
 
 {% block configuration %}
 
+  <h3>{% trans "VPN Configuration Package" %}</h3>
+
+  <p>
+    {% blocktrans trimmed %}
+      To allow other tinc hosts to join your VPN, you need to download a
+      package containing the current VPN hosts information. This file should
+      be provided to the new host who will join the VPN.
+    {% endblocktrans %}
+  </p>
+
+  <form class="form" method="post" action="{% url 'tinc:package' %}">
+    {% csrf_token %}
+
+      <input type="submit" class="btn btn-primary"
+             value="{% trans "Download package" %}"/>
+  </form>
+
+
   <h3>{% trans "Status" %}</h3>
 
   <p class="running-status-parent">

--- a/plinth/modules/tinc/templates/tinc.html
+++ b/plinth/modules/tinc/templates/tinc.html
@@ -1,0 +1,52 @@
+{% extends "simple_service.html" %}
+{% comment %}
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+{% endcomment %}
+
+{% load bootstrap %}
+{% load i18n %}
+
+
+{% block configuration %}
+
+  <h3>{% trans "Status" %}</h3>
+
+  <p class="running-status-parent">
+    {% if status.is_running %}
+      <span class='running-status active'></span>
+      {% trans "tinc is running" %}
+    {% else %}
+      <span class='running-status inactive'></span>
+      {% trans "tinc is not running" %}
+    {% endif %}
+  </p>
+
+  {% include "diagnostics_button.html" with module="tinc" %}
+
+  <h3>{% trans "Configuration" %}</h3>
+
+  <form class="form" method="post">
+    {% csrf_token %}
+
+    {{ form|bootstrap }}
+
+    <input type="submit" class="btn btn-primary"
+           value="{% trans "Update setup" %}"/>
+  </form>
+
+{% endblock %}

--- a/plinth/modules/tinc/templates/tinc_load.html
+++ b/plinth/modules/tinc/templates/tinc_load.html
@@ -1,3 +1,5 @@
+{% extends "simple_service.html" %}
+{% comment %}
 #
 # This file is part of Plinth.
 #
@@ -14,19 +16,31 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+{% endcomment %}
 
-"""
-URLs for the tinc module.
-"""
-
-from django.conf.urls import url
-
-from . import views
+{% load bootstrap %}
+{% load i18n %}
 
 
-urlpatterns = [
-    url(r'^apps/tinc/$', views.index, name='index'),
-    url(r'^apps/tinc/setup/$', views.setup, name='setup'),
-    url(r'^apps/tinc/package/$', views.package, name='package'),
-    url(r'^apps/tinc/load/$', views.load, name='load'),
-]
+{% block configuration %}
+
+  <h3>{% trans "Load VPN Configuration Package" %}</h3>
+
+  <p>
+    {% blocktrans trimmed %}
+      To join an existing tinc VPN, you will need to obtain a VPN
+      configuration package that contains information about other hosts in
+      the VPN.
+    {% endblocktrans %}
+  </p>
+
+  <form class="form" enctype="multipart/form-data" method="post">
+    {% csrf_token %}
+
+    {{ form|bootstrap }}
+
+    <input type="submit" class="btn btn-primary"
+           value="{% trans "Load package" %}"/>
+  </form>
+
+{% endblock %}

--- a/plinth/modules/tinc/templates/tinc_setup.html
+++ b/plinth/modules/tinc/templates/tinc_setup.html
@@ -1,0 +1,42 @@
+{% extends "simple_service.html" %}
+{% comment %}
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+{% endcomment %}
+
+{% load bootstrap %}
+{% load i18n %}
+
+
+{% block configuration %}
+
+  <h3>{% trans "Setup tinc" %}</h3>
+
+  <p>
+    {% trans "To begin using tinc, fill in the required information below." %}
+  </p>
+
+  <form class="form" method="post">
+    {% csrf_token %}
+
+    {{ form|bootstrap }}
+
+    <input type="submit" class="btn btn-primary"
+           value="{% trans "Perform setup" %}"/>
+  </form>
+
+{% endblock %}

--- a/plinth/modules/tinc/urls.py
+++ b/plinth/modules/tinc/urls.py
@@ -1,0 +1,30 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+URLs for the tinc module.
+"""
+
+from django.conf.urls import url
+
+from . import views
+
+
+urlpatterns = [
+    url(r'^apps/tinc/$', views.index, name='index'),
+    url(r'^apps/tinc/setup$', views.setup, name='setup'),
+]

--- a/plinth/modules/tinc/urls.py
+++ b/plinth/modules/tinc/urls.py
@@ -26,5 +26,6 @@ from . import views
 
 urlpatterns = [
     url(r'^apps/tinc/$', views.index, name='index'),
-    url(r'^apps/tinc/setup$', views.setup, name='setup'),
+    url(r'^apps/tinc/setup/$', views.setup, name='setup'),
+    url(r'^apps/tinc/package/$', views.package, name='package'),
 ]

--- a/plinth/modules/tinc/views.py
+++ b/plinth/modules/tinc/views.py
@@ -1,0 +1,125 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Views for the tinc module.
+"""
+
+import random
+import socket
+import string
+
+from django.contrib import messages
+from django.shortcuts import redirect
+from django.template.response import TemplateResponse
+from django.urls import reverse_lazy
+from django.utils.translation import ugettext as _
+
+from .forms import TincForm, TincSetupForm
+from plinth import actions
+from plinth.modules import tinc
+from plinth.modules.names import get_domain
+
+
+def index(request):
+    """Serve configuration page."""
+    status = get_status()
+    if not status['is_setup']:
+        return redirect(reverse_lazy('tinc:setup'))
+
+    form = None
+
+    if request.method == 'POST':
+        form = TincForm(request.POST, prefix='tinc')
+        if form.is_valid():
+            _apply_changes(request, status, form.cleaned_data)
+            status = get_status()
+            form = TincForm(initial=status, prefix='tinc')
+    else:
+        form = TincForm(initial=status, prefix='tinc')
+
+    return TemplateResponse(request, 'tinc.html',
+                            {'title': tinc.title,
+                             'description': tinc.description,
+                             'status': status,
+                             'form': form})
+
+
+def setup(request):
+    """Serve initial configuration page."""
+    status = get_status()
+
+    form = None
+
+    if request.method == 'POST':
+        form = TincSetupForm(request.POST, prefix='tinc')
+        if form.is_valid():
+            _setup(form.cleaned_data)
+            return redirect(reverse_lazy('tinc:index'))
+    else:
+        name = get_domain('domainname') or socket.gethostname()
+        # suggest a more random name for common hostnames
+        if name == 'freedombox' or name == 'debian':
+            name += '_' + ''.join(
+                random.choice(
+                    string.ascii_letters + string.digits) for x in range(20))
+        initial = {
+            'name': name,
+            'ip': '10.{0}.{1}.{2}'.format(
+                random.randint(0, 255),
+                random.randint(0, 255),
+                random.randint(0, 255)),
+            'address': get_domain('domainname'),
+        }
+        form = TincSetupForm(initial=initial, prefix='tinc')
+
+    return TemplateResponse(request, 'tinc_setup.html',
+                            {'title': tinc.title,
+                             'description': tinc.description,
+                             'status': status,
+                             'form': form})
+
+
+def get_status():
+    """Get the current status of tinc."""
+    return {'is_setup': tinc.is_setup(),
+            'enabled': tinc.service.is_enabled(),
+            'is_running': tinc.service.is_running()}
+
+
+def _setup(data):
+    """Setup a tinc VPN."""
+    actions.superuser_run(
+        'tinc', ['setup', '--name', data['name'], '--ip', data['ip'],
+                 '--address', data['address']])
+
+
+def _apply_changes(request, old_status, new_status):
+    """Apply the changes."""
+    modified = False
+
+    if old_status['enabled'] != new_status['enabled']:
+        if new_status['enabled']:
+            tinc.service.enable()
+        else:
+            tinc.service.disable()
+        modified = True
+
+    if modified:
+        messages.success(request, _('Configuration updated'))
+    else:
+        messages.info(request, _('Setting unchanged'))

--- a/plinth/modules/tinc/views.py
+++ b/plinth/modules/tinc/views.py
@@ -82,8 +82,7 @@ def setup(request):
                     string.ascii_letters + string.digits) for x in range(20))
         initial = {
             'name': name,
-            'ip': '10.{0}.{1}.{2}'.format(
-                random.randint(0, 255),
+            'ip_address': '10.10.{0}.{1}'.format(
                 random.randint(0, 255),
                 random.randint(0, 255)),
             'address': get_domain('domainname'),

--- a/plinth/modules/tinc/views.py
+++ b/plinth/modules/tinc/views.py
@@ -20,14 +20,17 @@ Views for the tinc module.
 """
 
 import random
+import shutil
 import socket
 import string
 
 from django.contrib import messages
+from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse_lazy
 from django.utils.translation import ugettext as _
+from django.views.decorators.http import require_POST
 
 from .forms import TincForm, TincSetupForm
 from plinth import actions
@@ -92,6 +95,25 @@ def setup(request):
                              'description': tinc.description,
                              'status': status,
                              'form': form})
+
+
+@require_POST
+def package(request):
+    """Provide VPN configuration package for download."""
+    package_name = shutil.make_archive(
+        'freedombox-tinc-package', 'gztar',
+        '/etc/tinc/freedombox', 'hosts')
+
+    with open(package_name, 'rb') as package_file:
+        package_string = package_file.read()
+
+    response = HttpResponse(package_string,
+                            content_type='application/gzip')
+    response['Content-Encoding'] = 'gzip'
+    response['Content-Disposition'] = \
+        'attachment; filename=freedombox-tinc-package.tar.gz'
+
+    return response
 
 
 def get_status():

--- a/plinth/modules/tinc/views.py
+++ b/plinth/modules/tinc/views.py
@@ -74,10 +74,10 @@ def setup(request):
             _setup(form.cleaned_data)
             return redirect(reverse_lazy('tinc:index'))
     else:
-        name = get_domain('domainname') or socket.gethostname()
+        name = socket.gethostname()
         # suggest a more random name for common hostnames
         if name == 'freedombox' or name == 'debian':
-            name += '_' + ''.join(
+            name += ''.join(
                 random.choice(
                     string.ascii_letters + string.digits) for x in range(20))
         initial = {
@@ -145,7 +145,7 @@ def get_status():
 def _setup(data):
     """Setup a tinc VPN."""
     actions.superuser_run(
-        'tinc', ['setup', '--name', data['name'], '--ip', data['ip'],
+        'tinc', ['setup', '--name', data['name'], '--ip', data['ip_address'],
                  '--address', data['address']])
 
 


### PR DESCRIPTION
This adds a basic module for tinc. The main difference between tinc and other VPNs is that in tinc, any host can act as client or server. (They call this "mesh routing" but hopefully it won't be confused with wireless mesh networking.) I recently found that tinc is also used to connect wireless mesh networks over VPN (https://github.com/freifunk/icvpn).

The module can also create a .tar.gz package containing the configuration for all hosts in the VPN. This package can be loaded into another FreedomBox (or any tinc node) to join the VPN. (I got the idea for this from https://github.com/jvasile/tinc-rollout)

TODOs:
- Allow setting the netmask
- Allow IPv6 addresses
- Allow changing configuration after setup complete
- Show my configured IP on the VPN
- Show configured hosts, with options to edit / delete / toggle connections
- Do some sanity checks when loading the .tar.gz package
