### PR TITLE
Monkey authentication - Phase 1

### DIFF
--- a/actions/monkeysphere
+++ b/actions/monkeysphere
@@ -28,12 +28,41 @@ import psutil
 import re
 import signal
 import subprocess
+import sys
+
+from plinth import action_utils
+
+
+SYSTEMD_SERVICE_PATH = '/etc/systemd/system/msva-web-plinth.service'
 
 
 def parse_arguments():
     """Return parsed command line arguments as dictionary."""
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest='subcommand', help='Sub command')
+
+    auth_enable = subparsers.add_parser(
+        'auth-enable', help='Enable web authentication using monkeysphere')
+    auth_enable.add_argument(
+        'domains', nargs='+',
+        help='List of domains to enable web authentication for')
+    auth_disable = subparsers.add_parser(
+        'auth-disable', help='Disable web authentication using monkeysphere')
+    auth_disable.add_argument(
+        'domains', nargs='+',
+        help='List of domains to disable web authentication for')
+    subparsers.add_parser(
+        'auth-get-certifiers', help='Retrieve the list of certifiers')
+    auth_add_certifier = subparsers.add_parser(
+        'auth-add-certifier', help='Add a list of certifiers')
+    auth_add_certifier.add_argument(
+        'certifier_fingerprint',
+        help='Fingerprint of the key to add as certifier')
+    auth_remove_certifier = subparsers.add_parser(
+        'auth-remove-certifier', help='Remove a list of certifiers')
+    auth_remove_certifier.add_argument(
+        'certifier_fingerprint',
+        help='Fingerprint of the cetifier key to remove')
 
     host_show_keys = subparsers.add_parser(
         'host-show-keys', help='Show imported/importable keys')
@@ -57,6 +86,165 @@ def parse_arguments():
     host_cancel_publish.add_argument('pid', help='PID of the publish process')
 
     return parser.parse_args()
+
+
+def augeas_load():
+    """Initialize Augeas."""
+    aug = augeas.Augeas(flags=augeas.Augeas.NO_LOAD +
+                        augeas.Augeas.NO_MODL_AUTOLOAD)
+    aug.set('/augeas/load/Httpd/lens', 'Httpd.lns')
+    aug.set('/augeas/load/Httpd/incl[last() + 1]',
+            '/etc/apache2/sites-available/*.conf')
+    aug.load()
+
+    return aug
+
+
+def _create_msva_user():
+    """Create a system user for monkeysphere validation agent daemon."""
+    try:
+        subprocess.run(['getent', 'passwd', 'msva-www'],
+                       stdout=subprocess.DEVNULL, check=True)
+        return
+    except subprocess.CalledProcessError:
+        pass
+
+    subprocess.run(['adduser', '--system', '--group', '--quiet', '--home',
+                    '/var/lib/msva-www', '--disabled-login', 'msva-www'])
+
+
+def _update_apache_environment():
+    """Set the monkeysphere validation agent address in Apache."""
+    env_file = '/etc/apache2/envvars'
+    with open(env_file, 'r') as conffile:
+        lines = conffile.readlines()
+
+    for line in lines:
+        if 'MONKEYSPHERE_VALIDATION_AGENT_SOCKET' in line:
+            return
+
+    with open(env_file, 'a') as file_handle:
+        file_handle.write('export MONKEYSPHERE_VALIDATION_AGENT_SOCKET='
+                          'http://127.0.0.1:5808\n')
+
+
+def _update_client_verify(domains, enable):
+    """Enable/disable web server configuration for client verification."""
+    aug = augeas_load()
+
+    for domain in domains:
+        file_name = '/etc/apache2/sites-available/{domain}.conf'
+        file_name = file_name.format(domain=domain)
+        if not os.path.isfile(file_name):
+            print('No configuration for domain: ' + domain, file=sys.stderr)
+            continue
+
+        aug_path = '/files' + file_name + '//VirtualHost'
+        method_path = aug_path + '/directive[. = "GnuTLSClientVerifyMethod"]'
+        verify_path = aug_path + '/directive[. = "GnuTLSClientVerify"]'
+        if enable:
+            _enable_client_verify(aug, aug_path, method_path, verify_path)
+        else:
+            aug.remove(method_path)
+            aug.remove(verify_path)
+
+    aug.save()
+
+
+def _enable_client_verify(aug, aug_path, method_path, verify_path):
+    """Write client verify configuration for a domain."""
+    if not aug.get(method_path):
+        aug.set(aug_path + '/directive[last() + 1]',
+                'GnuTLSClientVerifyMethod')
+
+    if not aug.get(verify_path):
+        aug.set(aug_path + '/directive[last() + 1]', 'GnuTLSClientVerify')
+
+    aug.set(method_path + '/arg', 'msva')
+    aug.set(verify_path + '/arg', 'request')
+
+
+def subcommand_auth_enable(arguments):
+    """Enable web authentication using monkeysphere."""
+    _create_msva_user()
+    action_utils.service_enable('msva-web-plinth')
+
+    _update_apache_environment()
+    _update_client_verify(arguments.domains, enable=True)
+    action_utils.service_restart('apache2')
+
+
+def subcommand_auth_disable(arguments):
+    """Disable web authentication using monkeysphere."""
+    _update_client_verify(arguments.domains, enable=False)
+    action_utils.service_restart('apache2')
+    action_utils.service_disable('msva-web-plinth')
+
+
+def _run_gpg_command(command, input=None):
+    """Run a GPG command as msva user."""
+    if input:
+        input = input.encode()
+
+    process = subprocess.run(['su', '-c', command, 'msva-www'],
+                             input=input, stdout=subprocess.PIPE, check=True)
+    return process.stdout.decode()
+
+
+def _assert_valid_fingerprint(fingerprint):
+    """Check that a given fingerprint is valid."""
+    if not re.match('^[A-Fa-f0-9]{40}$', fingerprint):
+        raise Exception('Invalid fingerprint')
+
+
+def subcommand_auth_get_certifiers(arguments):
+    """Print the list of certifiers."""
+    output = _run_gpg_command('gpg --list-keys --with-colon')
+    keys = []
+    context = None
+    for line in output.split('\n'):
+        fields = line.split(':')
+        if fields[0] == 'pub' and fields[1] == 'u':
+            context = 'pub'
+            keys.append({})
+        elif fields[0] == 'fpr' and context == 'pub':
+            keys[-1]['fingerprint'] = fields[9]
+        elif fields[0] == 'uid' and context == 'pub':
+            keys[-1].setdefault('uids', []).append(fields[9])
+        else:
+            context = None
+
+    print(json.dumps({'keys': keys}))
+
+
+def subcommand_auth_add_certifier(arguments):
+    """Add a certifier with ultimate trust for verifying auth keys."""
+    fingerprint = arguments.certifier_fingerprint
+    _assert_valid_fingerprint(fingerprint)
+
+    _run_gpg_command('gpg --recv-keys ' + fingerprint)
+
+    # Set 'ultimate' trust on the key
+    input = fingerprint + ':6:\n'
+    _run_gpg_command('gpg --import-ownertrust', input=input)
+    try:
+        _run_gpg_command('gpg --check-trustdb', input=input)
+    except subprocess.CalledProcessError:
+        pass
+
+
+def subcommand_auth_remove_certifier(arguments):
+    """Stop a certifier from verifying auth keys."""
+    fingerprint = arguments.certifier_fingerprint
+    _assert_valid_fingerprint(fingerprint)
+
+    # Set 'never' trust on the key
+    input = fingerprint + ':3:\n'
+    _run_gpg_command('gpg --import-ownertrust', input=input)
+    try:
+        _run_gpg_command('gpg --check-trustdb', input=input)
+    except subprocess.CalledProcessError:
+        pass
 
 
 def get_ssh_keys(fingerprint_hash):

--- a/data/lib/systemd/system/msva-web-plinth.service
+++ b/data/lib/systemd/system/msva-web-plinth.service
@@ -1,0 +1,36 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+[Unit]
+Description=Monkeysphere Validation Agent for Web
+Documentation=man:msva-perl(1)
+After=network.target
+
+[Service]
+Environment="MSVA_ALLOWED_USERS=www-data"
+Environment="MSVA_LOG_LEVEL=info"
+Environment="MSVA_PORT=5808"
+ExecStart=/usr/bin/msva-perl
+User=msva-www
+Group=msva-www
+Restart=always
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=msva-www
+
+[Install]
+WantedBy=multi-user.target

--- a/plinth/modules/monkeysphere/__init__.py
+++ b/plinth/modules/monkeysphere/__init__.py
@@ -22,12 +22,17 @@ Plinth module for monkeysphere.
 from django.utils.translation import ugettext_lazy as _
 
 from plinth import cfg
+from plinth import service as service_module
 
-version = 1
+version = 2
 
 depends = ['system']
 
-managed_packages = ['monkeysphere']
+service = None
+
+managed_services = ['msva-web-plinth']
+
+managed_packages = ['monkeysphere', 'msva-perl']
 
 title = _('Monkeysphere')
 
@@ -57,6 +62,10 @@ def init():
     menu = cfg.main_menu.get('system:index')
     menu.add_urlname(_('Monkeysphere'), 'glyphicon-certificate',
                      'monkeysphere:index')
+
+    global service
+    service = service_module.Service(
+        managed_services[0], title, ports=[], is_external=True)
 
 
 def setup(helper, old_version=None):

--- a/plinth/modules/monkeysphere/forms.py
+++ b/plinth/modules/monkeysphere/forms.py
@@ -1,0 +1,41 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Plinth module for configuring Monkeysphere.
+"""
+
+from django import forms
+from django.utils.translation import ugettext_lazy as _
+
+
+class MonkeysphereAuthForm(forms.Form):
+    """Monkeysphere authentication form."""
+    enabled = forms.BooleanField(
+        label=_('Enable web authentication using Monkeysphere'),
+        required=False)
+
+
+class MonkeysphereAuthAddForm(forms.Form):
+    """Monkeysphere authentication form to add certifiers."""
+    fingerprint = forms.RegexField(
+        label=_('OpenPGP Fingerprint'),
+        help_text=_('Fingerprint of an OpenPGP key that will be used to '
+                    'validate client keys. Example: '
+                    '1DEA112EDC105EDC0FEEDEC1A551F1ED1D0112ED'),
+        regex=r'^\s*[A-Fa-f0-9]{40}\s*$',
+        required=True)

--- a/plinth/modules/monkeysphere/templates/monkeysphere_authentication.html
+++ b/plinth/modules/monkeysphere/templates/monkeysphere_authentication.html
@@ -1,0 +1,132 @@
+{% extends "base.html" %}
+{% comment %}
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+{% endcomment %}
+
+{% load bootstrap %}
+{% load i18n %}
+
+{% block content %}
+
+  <h2>{{ title }}</h2>
+
+  <p>
+    {% blocktrans trimmed %}
+      Monkeysphere can be used to authenticate visitors by using
+      OpenPGP keys as HTTPS client certificates.
+    {% endblocktrans %}
+  </p>
+
+  <p>
+    {% blocktrans trimmed %}
+      A client intending to authenticate with {{ box_name }} using
+      this method will need an OpenPGP public/private key pair.  This
+      key needs be signed by another key after verifying the identity
+      of the client such as during a key signing party.  The public
+      key of the client and the signatures need to be published on a
+      keyserver.  Client then generates an X509 client certificate
+      from this key pair and imports it into a browser.  When using
+      services of {{ box_name }}, browser submits this certificate
+      automatically for verification and the client is verified
+      without the need for a password.
+    {% endblocktrans %}
+  </p>
+
+  <p>
+    {% blocktrans trimmed %}
+      The signing key is known here as a certifier.  A list of
+      certifiers as managed here will be trusted 'ultimately'.  When a
+      client's certificate is received by {{ box_name }}, it is
+      accepted as valid if any of the certifiers have signed the key.
+    {% endblocktrans %}
+  </p>
+
+  <h3>Status</h3>
+  <p class="running-status-parent">
+    {% if status.is_running %}
+      <span class="running-status active"></span>
+      {% blocktrans trimmed with service_name=service_name %}
+        Service <i>{{ service_name }}</i> is running
+      {% endblocktrans %}
+    {% else %}
+      <span class="running-status inactive"></span>
+      {% blocktrans trimmed with service_name=service_name %}
+        Service <i>{{ service_name }}</i> is not running
+      {% endblocktrans %}
+    {% endif %}
+  </p>
+
+  <h3>Configuration</h3>
+
+  <form class="form" method="post">
+    {% csrf_token %}
+
+    {{ form|bootstrap }}
+
+    <input type="submit" class="btn btn-primary"
+           value="{% trans "Update setup" %}"/>
+  </form>
+
+  <h3>Certifiers</h3>
+
+  {% if status.keys %}
+    <table class="table table-bordered table-condensed table-striped">
+      <thead>
+        <tr>
+          <th>{% trans "UID" %}</th>
+          <th>{% trans "Fingerprint" %}</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for key in status.keys %}
+          <tr>
+            <td>
+              {% for uid in key.uids %}
+                <p>{{ uid }}</p>
+              {% endfor %}
+            </td>
+            <td>{{ key.fingerprint }}</td>
+            <td>
+              <form class="form pull-right" method="post"
+                    action="{% url 'monkeysphere:authentication_remove' key.fingerprint %}">
+                {% csrf_token %}
+
+                <button type="submit" class="btn btn-danger btn-sm pull-right">
+                  {% trans "Remove" %}</button>
+              </form>
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% else %}
+    <p>{% trans "No certifing keys added." %}</p>
+  {% endif %}
+
+  <form class="form" method="post"
+        action="{% url 'monkeysphere:authentication_add' %}">
+    {% csrf_token %}
+
+    {{ add_form|bootstrap }}
+
+    <button type="submit" class="btn btn-default">
+      {% trans "Add Certifier" %}</button>
+  </form>
+
+{% endblock %}

--- a/plinth/modules/monkeysphere/urls.py
+++ b/plinth/modules/monkeysphere/urls.py
@@ -33,4 +33,11 @@ urlpatterns = [
     url(r'^sys/monkeysphere/(?P<fingerprint>[0-9A-Fa-f]+)/publish/$',
         views.publish, name='publish'),
     url(r'^sys/monkeysphere/cancel/$', views.cancel, name='cancel'),
+    url(r'^sys/monkeysphere/authentication/$', views.authentication,
+        name='authentication'),
+    url(r'^sys/monkeysphere/authentication/remove/'
+        r'(?P<fingerprint>[0-9A-Fa-f]+)/publish/$',
+        views.authentication_remove, name='authentication_remove'),
+    url(r'^sys/monkeysphere/authentication/add/$',
+        views.authentication_add, name='authentication_add'),
 ]

--- a/plinth/modules/monkeysphere/views.py
+++ b/plinth/modules/monkeysphere/views.py
@@ -27,21 +27,28 @@ from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
 import json
 
+from .forms import MonkeysphereAuthForm, MonkeysphereAuthAddForm
 from plinth import actions
 from plinth.modules import monkeysphere
 from plinth.modules import names
 
 publish_process = None
 
+subsubmenu = [{'url': reverse_lazy('monkeysphere:index'),
+               'text': _('Host Verification')},
+              {'url': reverse_lazy('monkeysphere:authentication'),
+               'text': _('Authentication')}]
+
 
 def index(request):
-    """Serve configuration page."""
+    """Serve host verification page."""
     _collect_publish_result(request)
     status = get_status()
     return TemplateResponse(
         request, 'monkeysphere.html',
         {'title': monkeysphere.title,
          'description': monkeysphere.description,
+         'subsubmenu': subsubmenu,
          'status': status,
          'running': bool(publish_process)})
 
@@ -147,3 +154,112 @@ def _collect_publish_result(request):
         messages.error(request, _('Error occurred while publishing key.'))
 
     publish_process = None
+
+
+def authentication(request):
+    """Serve user authentication page."""
+    status = get_auth_status()
+
+    form = None
+    if request.method == 'POST':
+        form = MonkeysphereAuthForm(request.POST, prefix='monkeysphere-auth')
+        # pylint: disable=E1101
+        if form.is_valid():
+            _apply_changes(request, status, form.cleaned_data)
+            status = get_status()
+            form = MonkeysphereAuthForm(initial=status,
+                                        prefix='monkeysphere-auth')
+    else:
+        form = MonkeysphereAuthForm(initial=status, prefix='monkeysphere-auth')
+
+    add_form = MonkeysphereAuthAddForm(prefix='monkeysphere-auth-add')
+    context = {'title': _('Monkeysphere Authentication'),
+               'subsubmenu': subsubmenu,
+               'status': status,
+               'form': form,
+               'add_form': add_form,
+               'service_name': _('Monkeysphere Validation Agent for Web')}
+    return TemplateResponse(request, 'monkeysphere_authentication.html',
+                            context)
+
+
+@require_POST
+def authentication_remove(request, fingerprint):
+    """Remove a certifier key from authenticating keys."""
+    try:
+        actions.superuser_run('monkeysphere',
+                              ['auth-remove-certifier', fingerprint])
+        messages.success(request, _('Certifier removed.'))
+    except actions.ActionError:
+        messages.error(request, _('Error removing certifier.'))
+
+    return redirect(reverse_lazy('monkeysphere:authentication'))
+
+
+@require_POST
+def authentication_add(request):
+    """Remove a certifier key from authenticating keys."""
+    form = MonkeysphereAuthAddForm(
+        request.POST, prefix='monkeysphere-auth-add')
+    _add_fingerprint(request, form)
+
+    return redirect(reverse_lazy('monkeysphere:authentication'))
+
+
+def get_auth_status():
+    """Return the status of authentication based on monkeysphere."""
+    output = actions.superuser_run('monkeysphere', ['auth-get-certifiers'])
+    keys = json.loads(output)['keys']
+
+    return {'enabled': monkeysphere.service.is_enabled(),
+            'is_running': monkeysphere.service.is_running(),
+            'keys': keys}
+
+
+def _apply_changes(request, old_status, new_status):
+    """Apply the changes."""
+    modified = False
+
+    if old_status['enabled'] != new_status['enabled']:
+        domains = _get_domains()
+        if new_status['enabled']:
+            actions.superuser_run('monkeysphere', ['auth-enable'] + domains)
+        else:
+            actions.superuser_run('monkeysphere', ['auth-disable'] + domains)
+
+        modified = True
+
+    if modified:
+        messages.success(request, _('Configuration updated'))
+    else:
+        messages.info(request, _('Setting unchanged'))
+
+
+def _add_fingerprint(request, form):
+    """Add a fingerprint as certifier."""
+    if not form.is_valid():
+        messages.error(request, _('Invalid OpenPGP fingerprint.'))
+        return
+
+    fingerprint = form.cleaned_data['fingerprint']
+    try:
+        actions.superuser_run(
+            'monkeysphere', ['auth-add-certifier', fingerprint])
+        messages.success(
+            request, _('Successfully added fingerprint: {fingerprint}').format(
+                fingerprint=fingerprint))
+    except actions.ActionError as action_error:
+        messages.error(request, _('Failed to certifier.  Please ensure that '
+                                  'it is available from key servers.'))
+
+
+def _get_domains():
+    """Return list of domains for which monkeysphere auth is applicable."""
+    domains = ['default-tls']
+    for domain_type in names.domains:
+        if domain_type == 'hiddenservice':
+            continue
+
+        domains.extend(names.domains[domain_type])
+
+    return domains

--- a/plinth/modules/monkeysphere/views.py
+++ b/plinth/modules/monkeysphere/views.py
@@ -48,7 +48,6 @@ def index(request):
         request, 'monkeysphere.html',
         {'title': monkeysphere.title,
          'description': monkeysphere.description,
-         'subsubmenu': subsubmenu,
          'status': status,
          'running': bool(publish_process)})
 

--- a/plinth/templates/service.html
+++ b/plinth/templates/service.html
@@ -40,10 +40,14 @@
       <p class="running-status-parent">
         {% if service.is_running %}
           <span class="running-status active"></span>
-          Service <i>{{ service.name }}</i> {% trans "is running" %}
+          {% blocktrans trimmed with service_name=service.name %}
+            Service <i>{{ service_name }}</i> is running
+          {% endblocktrans %}
         {% else %}
           <span class="running-status inactive"></span>
-          Service <i>{{ service.name }}</i> {% trans "is not running" %}
+          {% blocktrans trimmed with service_name=service.name %}
+            Service <i>{{ service_name }}</i> is not running
+          {% endblocktrans %}
         {% endif %}
       </p>
     {% endif %}

--- a/setup.py
+++ b/setup.py
@@ -210,7 +210,7 @@ setuptools.setup(
                  ['data/etc/NetworkManager/dispatcher.d/10-freedombox-batman']),
                 ('/etc/sudoers.d', ['data/etc/sudoers.d/plinth']),
                 ('/lib/systemd/system',
-                 ['data/lib/systemd/system/plinth.service']),
+                 glob.glob('data/lib/systemd/system/*.service')),
                 ('/usr/share/plinth/actions',
                  glob.glob(os.path.join('actions', '*'))),
                 ('/usr/share/polkit-1/rules.d',


### PR DESCRIPTION
This pull request implements setting up Monkeysphere validation agent configuring Apache for it and managing it's list of certifiers.  The menu item to reach monkeysphere authentication UI is currently disabled and some rough edges exist.

Phase 2 is to use mod-auth-pubtkt to setup actual authentication into FreedomBox services with the help of email field.
