### PR TITLE
Uninstall modules

### DIFF
--- a/actions/packages
+++ b/actions/packages
@@ -42,6 +42,12 @@ def parse_arguments():
     subparser.add_argument(
         'packages', nargs='+', help='list of packages to install')
 
+    subparser = subparsers.add_parser('remove', help='remove packages')
+    subparser.add_argument(
+        'module', help='name of module for which package is being removed')
+    subparser.add_argument(
+        'packages', nargs='+', help='list of packages to remove')
+
     return parser.parse_args()
 
 
@@ -78,6 +84,17 @@ def subcommand_install(arguments):
         sys.exit(99)
 
     _run_apt_command(['install'] + arguments.packages)
+
+
+def subcommand_remove(arguments):
+    """Remove packages using apt-get."""
+    try:
+        _assert_managed_packages(arguments.module, arguments.packages)
+    except Exception as exception:
+        print('Access check failed:', exception, file=sys.stderr)
+        sys.exit(99)
+
+    _run_apt_command(['remove'] + arguments.packages)
 
 
 def _assert_managed_packages(module, packages):

--- a/plinth/modules/datetime/__init__.py
+++ b/plinth/modules/datetime/__init__.py
@@ -53,8 +53,7 @@ def init():
 
     global service
     service = service_module.Service(
-        managed_services[0], title, ports=['ntp'], is_external=False,
-        allow_uninstall=False)
+        managed_services[0], title, ports=['ntp'], is_external=False)
 
 
 def setup(helper, old_version=None):

--- a/plinth/modules/datetime/__init__.py
+++ b/plinth/modules/datetime/__init__.py
@@ -53,7 +53,8 @@ def init():
 
     global service
     service = service_module.Service(
-        managed_services[0], title, ports=['ntp'], is_external=False)
+        managed_services[0], title, ports=['ntp'], is_external=False,
+        allow_uninstall=False)
 
 
 def setup(helper, old_version=None):

--- a/plinth/modules/datetime/views.py
+++ b/plinth/modules/datetime/views.py
@@ -36,6 +36,7 @@ class DateTimeServiceView(ServiceView):
     form_class = DateTimeForm
     service_id = datetime.managed_services[0]
     diagnostics_module_name = "datetime"
+    is_module_essential = datetime.is_essential
 
     def get_initial(self):
         return {'is_enabled': self.service.is_enabled(),

--- a/plinth/modules/deluge/urls.py
+++ b/plinth/modules/deluge/urls.py
@@ -22,7 +22,7 @@ URLs for the Deluge module.
 from django.conf.urls import url
 
 from plinth.modules import deluge
-from plinth.views import ServiceView
+from plinth.views import ServiceView, UninstallView
 
 
 urlpatterns = [
@@ -31,4 +31,6 @@ urlpatterns = [
             diagnostics_module_name="deluge",
             service_id=deluge.managed_services[0]
         ), name='index'),
+    url(r'^apps/deluge/uninstall/$',
+        UninstallView.as_view(), name='uninstall'),
 ]

--- a/plinth/modules/ikiwiki/urls.py
+++ b/plinth/modules/ikiwiki/urls.py
@@ -22,6 +22,7 @@ URLs for the ikiwiki module
 from django.conf.urls import url
 
 from . import views
+from plinth.views import UninstallView
 
 
 urlpatterns = [
@@ -31,4 +32,6 @@ urlpatterns = [
     url(r'^apps/ikiwiki/(?P<name>[\w.@+-]+)/delete/$', views.delete,
         name='delete'),
     url(r'^apps/ikiwiki/create/$', views.create, name='create'),
+    url(r'^apps/ikiwiki/uninstall/$',
+        UninstallView.as_view(), name='uninstall'),
 ]

--- a/plinth/modules/minetest/urls.py
+++ b/plinth/modules/minetest/urls.py
@@ -22,8 +22,11 @@ URLs for the minetest module.
 from django.conf.urls import url
 
 from plinth.modules.minetest import MinetestServiceView
+from plinth.views import UninstallView
 
 
 urlpatterns = [
     url(r'^apps/minetest/$', MinetestServiceView.as_view(), name='index'),
+    url(r'^apps/minetest/uninstall/$',
+        UninstallView.as_view(), name='uninstall'),
 ]

--- a/plinth/modules/mumble/urls.py
+++ b/plinth/modules/mumble/urls.py
@@ -22,8 +22,11 @@ URLs for the Mumble module
 from django.conf.urls import url
 
 from plinth.modules.mumble import MumbleServiceView
+from plinth.views import UninstallView
 
 
 urlpatterns = [
     url(r'^apps/mumble/$', MumbleServiceView.as_view(), name='index'),
+    url(r'^apps/mumble/uninstall/$',
+        UninstallView.as_view(), name='uninstall'),
 ]

--- a/plinth/modules/privoxy/urls.py
+++ b/plinth/modules/privoxy/urls.py
@@ -22,8 +22,11 @@ URLs for the Privoxy module.
 from django.conf.urls import url
 
 from plinth.modules.privoxy import PrivoxyServiceView
+from plinth.views import UninstallView
 
 
 urlpatterns = [
     url(r'^apps/privoxy/$', PrivoxyServiceView.as_view(), name='index'),
+    url(r'^apps/privoxy/uninstall/$',
+        UninstallView.as_view(), name='uninstall'),
 ]

--- a/plinth/modules/quassel/urls.py
+++ b/plinth/modules/quassel/urls.py
@@ -22,8 +22,11 @@ URLs for the quassel module.
 from django.conf.urls import url
 
 from plinth.modules.quassel import QuasselServiceView
+from plinth.views import UninstallView
 
 
 urlpatterns = [
     url(r'^apps/quassel/$', QuasselServiceView.as_view(), name='index'),
+    url(r'^apps/quassel/uninstall/$',
+        UninstallView.as_view(), name='uninstall'),
 ]

--- a/plinth/modules/radicale/urls.py
+++ b/plinth/modules/radicale/urls.py
@@ -22,8 +22,11 @@ URLs for the radicale module.
 from django.conf.urls import url
 
 from .views import RadicaleServiceView
+from plinth.views import UninstallView
 
 
 urlpatterns = [
     url(r'^apps/radicale/$', RadicaleServiceView.as_view(), name='index'),
+    url(r'^apps/radicale/uninstall/$',
+        UninstallView.as_view(), name='uninstall'),
 ]

--- a/plinth/modules/repro/urls.py
+++ b/plinth/modules/repro/urls.py
@@ -22,8 +22,11 @@ URLs for the repro module.
 from django.conf.urls import url
 
 from plinth.modules.repro import ReproServiceView
+from plinth.views import UninstallView
 
 
 urlpatterns = [
     url(r'^apps/repro/$', ReproServiceView.as_view(), name='index'),
+    url(r'^apps/repro/uninstall/$',
+        UninstallView.as_view(), name='uninstall'),
 ]

--- a/plinth/modules/roundcube/urls.py
+++ b/plinth/modules/roundcube/urls.py
@@ -21,7 +21,7 @@ URLs for the Roundcube module.
 
 from django.conf.urls import url
 
-from plinth.views import ServiceView
+from plinth.views import ServiceView, UninstallView
 from plinth.modules import roundcube
 
 
@@ -32,4 +32,6 @@ urlpatterns = [
             description=roundcube.description,
             show_status_block=False
         ), name='index'),
+    url(r'^apps/roundcube/uninstall/$',
+        UninstallView.as_view(), name='uninstall'),
 ]

--- a/plinth/modules/shaarli/urls.py
+++ b/plinth/modules/shaarli/urls.py
@@ -21,7 +21,7 @@ URLs for the Shaarli module.
 
 from django.conf.urls import url
 
-from plinth.views import ServiceView
+from plinth.views import ServiceView, UninstallView
 from plinth.modules import shaarli
 
 
@@ -31,4 +31,6 @@ urlpatterns = [
             description=shaarli.description,
             show_status_block=False,
         ), name='index'),
+    url(r'^apps/shaarli/uninstall/$',
+        UninstallView.as_view(), name='uninstall'),
 ]

--- a/plinth/modules/transmission/urls.py
+++ b/plinth/modules/transmission/urls.py
@@ -22,9 +22,12 @@ URLs for the Transmission module.
 from django.conf.urls import url
 
 from .views import TransmissionServiceView
+from plinth.views import UninstallView
 
 
 urlpatterns = [
     url(r'^apps/transmission/$',
         TransmissionServiceView.as_view(), name='index'),
+    url(r'^apps/transmission/uninstall/$',
+        UninstallView.as_view(), name='uninstall'),
 ]

--- a/plinth/modules/ttrss/urls.py
+++ b/plinth/modules/ttrss/urls.py
@@ -21,7 +21,7 @@ URLs for the Tiny Tiny RSS module.
 
 from django.conf.urls import url
 
-from plinth.views import ServiceView
+from plinth.views import ServiceView, UninstallView
 from plinth.modules import ttrss
 
 
@@ -32,4 +32,6 @@ urlpatterns = [
             description=ttrss.description,
             show_status_block=False
         ), name='index'),
+    url(r'^apps/ttrss/uninstall/$',
+        UninstallView.as_view(), name='uninstall'),
 ]

--- a/plinth/modules/xmpp/urls.py
+++ b/plinth/modules/xmpp/urls.py
@@ -22,9 +22,12 @@ URLs for the XMPP module
 from django.conf.urls import url
 
 from .views import EjabberdServiceView, JsxcView
+from plinth.views import UninstallView
 
 
 urlpatterns = [
     url(r'^apps/xmpp/$', EjabberdServiceView.as_view(), name='index'),
     url(r'^apps/xmpp/jsxc/$', JsxcView.as_view(), name='jsxc'),
+    url(r'^apps/xmpp/uninstall/$',
+        UninstallView.as_view(), name='uninstall'),
 ]

--- a/plinth/package.py
+++ b/plinth/package.py
@@ -84,6 +84,15 @@ class Transaction(object):
             logger.exception('Error installing package: %s', exception)
             raise
 
+    def uninstall(self):
+        """Run an apt-get transaction to remove given packages."""
+        try:
+            self._run_apt_command(['remove', self.module_name] +
+                                  self.package_names)
+        except subprocess.CalledProcessError as exception:
+            logger.exception('Error removing package: %s', exception)
+            raise
+
     def _run_apt_command(self, arguments):
         """Run apt-get and update progress."""
         self._reset_status()

--- a/plinth/service.py
+++ b/plinth/service.py
@@ -45,7 +45,8 @@ class Service(object):
     - is_running (optional): Boolean or a method returning Boolean
     """
     def __init__(self, service_id, name, ports=None, is_external=False,
-                 is_enabled=None, enable=None, disable=None, is_running=None):
+                 is_enabled=None, enable=None, disable=None, is_running=None,
+                 allow_uninstall=True):
         if ports is None:
             ports = []
 
@@ -60,6 +61,7 @@ class Service(object):
         self._enable = enable
         self._disable = disable
         self._is_running = is_running
+        self.allow_uninstall = allow_uninstall
 
         # Maintain a complete list of services
         assert(service_id not in services)

--- a/plinth/service.py
+++ b/plinth/service.py
@@ -45,8 +45,7 @@ class Service(object):
     - is_running (optional): Boolean or a method returning Boolean
     """
     def __init__(self, service_id, name, ports=None, is_external=False,
-                 is_enabled=None, enable=None, disable=None, is_running=None,
-                 allow_uninstall=True):
+                 is_enabled=None, enable=None, disable=None, is_running=None):
         if ports is None:
             ports = []
 
@@ -61,7 +60,6 @@ class Service(object):
         self._enable = enable
         self._disable = disable
         self._is_running = is_running
-        self.allow_uninstall = allow_uninstall
 
         # Maintain a complete list of services
         assert(service_id not in services)

--- a/plinth/templates/service.html
+++ b/plinth/templates/service.html
@@ -68,4 +68,18 @@
     </form>
   {% endblock %}
 
+  {% block uninstall %}
+    {% if diagnostics_module_name and service.allow_uninstall %}
+      <br>
+      <p>
+        <a class="btn btn-default btn-md"
+           href="{% url 'uninstall' diagnostics_module_name %}">
+          <span class="glyphicon glyphicon-trash"
+                aria-hidden="true"></span>
+          {% trans "Uninstall &raquo;" %}
+        </a>
+      </p>
+    {% endif %}
+  {% endblock %}
+
 {% endblock %}

--- a/plinth/templates/service.html
+++ b/plinth/templates/service.html
@@ -69,7 +69,7 @@
   {% endblock %}
 
   {% block uninstall %}
-    {% if diagnostics_module_name and service.allow_uninstall %}
+    {% if diagnostics_module_name and not is_module_essential %}
       <br>
       <p>
         <a class="btn btn-default btn-md"

--- a/plinth/templates/service.html
+++ b/plinth/templates/service.html
@@ -69,11 +69,11 @@
   {% endblock %}
 
   {% block uninstall %}
-    {% if diagnostics_module_name and not is_module_essential %}
+    {% if uninstall_url %}
       <br>
       <p>
         <a class="btn btn-default btn-md"
-           href="{% url 'uninstall' diagnostics_module_name %}">
+           href="{% url uninstall_url %}">
           <span class="glyphicon glyphicon-trash"
                 aria-hidden="true"></span>
           {% trans "Uninstall &raquo;" %}

--- a/plinth/templates/uninstall.html
+++ b/plinth/templates/uninstall.html
@@ -1,3 +1,5 @@
+{% extends "base.html" %}
+{% comment %}
 #
 # This file is part of Plinth.
 #
@@ -14,16 +16,37 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+{% endcomment %}
 
-"""
-Django URLconf file containing all urls
-"""
+{% load bootstrap %}
+{% load i18n %}
 
-from django.conf.urls import url
-from . import views
+{% block content %}
 
-urlpatterns = [
-    url(r'^$', views.index, name='index'),
-    url(r'^uninstall/(?P<modulename>\w+)/$', views.uninstall,
-        name='uninstall'),
-]
+  <h2>{{ title }}</h2>
+
+  <p>
+    {% trans "The following packages will be removed:" %}
+    <ul>
+      {% for package in packages %}
+        <li>{{ package }}</li>
+      {% endfor %}
+    </ul>
+  </p>
+
+  <p>
+    {% blocktrans trimmed %}
+      Are you sure you want to uninstall?
+    {% endblocktrans %}
+  </p>
+
+  <form class="form" method="post">
+    {% csrf_token %}
+
+    {{ form|bootstrap }}
+
+    <input type="submit" class="btn btn-primary"
+           value="{% trans "Uninstall" %}"/>
+  </form>
+
+{% endblock %}

--- a/plinth/templates/uninstall.html
+++ b/plinth/templates/uninstall.html
@@ -21,32 +21,63 @@
 {% load bootstrap %}
 {% load i18n %}
 
+{% block page_head %}
+
+  {% if setup_helper.current_operation %}
+    <meta http-equiv="refresh" content="3" />
+  {% endif %}
+
+{% endblock %}
+
+
 {% block content %}
 
-  <h2>{{ title }}</h2>
+  <h2>{% trans "Uninstall" %}: {{ setup_helper.module.title }}</h2>
 
-  <p>
-    {% trans "The following packages will be removed:" %}
-    <ul>
-      {% for package in packages %}
-        <li>{{ package }}</li>
-      {% endfor %}
-    </ul>
-  </p>
+  {% if not setup_helper.current_operation %}
+    <p>
+      {% trans "The following packages will be removed:" %}
+      <ul>
+        {% for package in setup_helper.module.managed_packages %}
+          <li>{{ package }}</li>
+        {% endfor %}
+      </ul>
+    </p>
 
-  <p>
-    {% blocktrans trimmed %}
-      Are you sure you want to uninstall?
-    {% endblocktrans %}
-  </p>
+    <p>
+      {% blocktrans trimmed %}
+        Are you sure you want to uninstall?
+      {% endblocktrans %}
+    </p>
 
-  <form class="form" method="post">
-    {% csrf_token %}
+    <form action="" method="post">
+      {% csrf_token %}
 
-    {{ form|bootstrap }}
+      <input type="submit" class="btn btn-md btn-primary"
+             value="{% trans "Uninstall" %}" />
+    </form>
 
-    <input type="submit" class="btn btn-primary"
-           value="{% trans "Uninstall" %}"/>
-  </form>
+  {% else %}
+    {% with transaction=setup_helper.current_operation.transaction %}
+      <div>
+        {% blocktrans trimmed with package_names=transaction.package_names|join:", " status=transaction.status_string %}
+          Uninstalling {{ package_names }}: {{ status }}
+        {% endblocktrans %}
+      </div>
+      <div class="progress">
+        <div class="progress-bar progress-bar-striped active"
+             role="progressbar" aria-valuemin="0" aria-valuemax="100"
+             aria-valuenow="{{ transaction.percentage }}"
+             style="width: {{ transaction.percentage }}%">
+          <span class="sr-only">
+            {% blocktrans trimmed with percentage=transaction.percentage %}
+              {{ percentage }}% complete
+            {% endblocktrans %}
+          </span>
+        </div>
+      </div>
+    {% endwith %}
+
+  {% endif %}
 
 {% endblock %}

--- a/plinth/tests/test_middleware.py
+++ b/plinth/tests/test_middleware.py
@@ -109,7 +109,7 @@ class TestSetupMiddleware(TestCase):
         resolve.return_value.namespaces = ['mockapp']
         module = Mock()
         module.setup_helper.is_finished = True
-        module.setup_helper.collect_result.return_value = None
+        module.setup_helper.collect_result.return_value = ('setup', None)
         module.setup_helper.get_state.return_value = 'up-to-date'
         loaded_modules.__getitem__.return_value = module
 

--- a/plinth/urls.py
+++ b/plinth/urls.py
@@ -24,6 +24,6 @@ from . import views
 
 urlpatterns = [
     url(r'^$', views.index, name='index'),
-    url(r'^uninstall/(?P<modulename>\w+)/$', views.uninstall,
+    url(r'^apps/uninstall/(?P<modulename>\w+)/$', views.uninstall,
         name='uninstall'),
 ]

--- a/plinth/urls.py
+++ b/plinth/urls.py
@@ -24,6 +24,4 @@ from . import views
 
 urlpatterns = [
     url(r'^$', views.index, name='index'),
-    url(r'^apps/uninstall/(?P<modulename>\w+)/$', views.uninstall,
-        name='uninstall'),
 ]

--- a/plinth/views.py
+++ b/plinth/views.py
@@ -92,6 +92,7 @@ class ServiceView(FormView):
     # This block uses information from service.is_running. This method is
     # optional, so allow not showing this block here.
     show_status_block = True
+    is_module_essential = False
 
     @property
     def success_url(self):
@@ -145,6 +146,7 @@ class ServiceView(FormView):
         if self.description:
             context['description'] = self.description
         context['show_status_block'] = self.show_status_block
+        context['is_module_essential'] = self.is_module_essential
         return context
 
 


### PR DESCRIPTION
This adds an "Uninstall" button to the bottom of the page, for apps using the "service" view and template. The uninstall button won't be shown for essential services. When the user clicks "Uninstall", they are shown a confirmation page that lists all the packages that will be removed.

![plinth_uninstall1](https://cloud.githubusercontent.com/assets/178876/20032057/ae362134-a358-11e6-8fd8-11f2176f1d6b.png)

![plinth_uninstall2](https://cloud.githubusercontent.com/assets/178876/20032058/af38ec92-a358-11e6-9e5b-9ad1bb7164d0.png)