### PR TITLE
actions: Allow not printing error when an action fails

### DIFF
--- a/plinth/actions.py
+++ b/plinth/actions.py
@@ -109,12 +109,12 @@ def run(action, options=None, input=None, async=False):
     return _run(action, options, input, async, False)
 
 
-def superuser_run(action, options=None, input=None, async=False):
+def superuser_run(action, options=None, input=None, async=False, expecting_error=True):
     """Safely run a specific action as root.
 
     See actions._run for more information.
     """
-    return _run(action, options, input, async, True)
+    return _run(action, options, input, async, True, expecting_error=expecting_error)
 
 
 def run_as_user(action, options=None, input=None, async=False,
@@ -127,7 +127,7 @@ def run_as_user(action, options=None, input=None, async=False,
 
 
 def _run(action, options=None, input=None, async=False, run_as_root=False,
-         become_user=None):
+         become_user=None, expecting_error=True):
     """Safely run a specific action as a normal user or root.
 
     Actions are pulled from the actions directory.
@@ -186,8 +186,9 @@ def _run(action, options=None, input=None, async=False, run_as_root=False,
         output, error = proc.communicate(input=input)
         output, error = output.decode(), error.decode()
         if proc.returncode != 0:
-            LOGGER.error('Error executing command - %s, %s, %s', cmd, output,
-                         error)
+            if expecting_error:
+                LOGGER.error('Error executing command - %s, %s, %s', cmd, output,
+                             error)
             raise ActionError(action, output, error)
 
         return output

--- a/plinth/package.py
+++ b/plinth/package.py
@@ -136,7 +136,7 @@ class Transaction(object):
 def is_package_manager_busy():
     """Return whether a package manager is running."""
     try:
-        actions.superuser_run('packages', ['is-package-manager-busy'])
+        actions.superuser_run('packages', ['is-package-manager-busy'], expecting_error=False)
         return True
     except actions.ActionError:
         return False


### PR DESCRIPTION
When we are starting the server with superuser action packages show ERROR log message which is not correct