### PR TITLE
firstboot: collect steps irrespective of whether setup is done

### DIFF
--- a/plinth/modules/first_boot/__init__.py
+++ b/plinth/modules/first_boot/__init__.py
@@ -14,13 +14,13 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-
 """
 Plinth module for first boot wizard
 """
 
-from django.urls import reverse
 import operator
+
+from django.urls import reverse
 
 from plinth import module_loader
 
@@ -70,8 +70,7 @@ def _get_steps():
     modules = module_loader.loaded_modules
     for module_object in modules.values():
         if getattr(module_object, 'first_boot_steps', None):
-            if module_object.setup_helper.get_state() != 'needs-setup':
-                steps.extend(module_object.first_boot_steps)
+            steps.extend(module_object.first_boot_steps)
 
     _all_first_boot_steps = sorted(steps, key=operator.itemgetter('order'))
     return _all_first_boot_steps


### PR DESCRIPTION
The cached variable `_all_first_boot_steps` does not contain the firstboot step
from `users` module since its setup wasn't done at the time that this variable
was initialized.

Checking whether setup is done is now no longer necessary since first setup is
now moved into Plinth from freedombox-setup. Removing this check ensures that
the variable `_all_first_boot_steps` is properly initialized.

Closes #1193

Signed-off-by: Joseph Nuthalapati <njoseph@thoughtworks.com>