### PR TITLE
UX improvements for the first setup page

### DIFF
--- a/plinth/templates/first_setup.html
+++ b/plinth/templates/first_setup.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "base_firstboot.html" %}
 {% comment %}
 #
 # This file is part of Plinth.
@@ -20,13 +20,10 @@
 
 {% load bootstrap %}
 {% load i18n %}
+{% load static %}
 
 {% block page_head %}
-
-  {% if setup_helper.current_operation %}
-    <meta http-equiv="refresh" content="3" />
-  {% endif %}
-
+  <meta http-equiv="refresh" content="3" />
 {% endblock %}
 
 
@@ -40,5 +37,10 @@
       {% endblocktrans %}
     </div>
   {% endif %}
+
+  <p class="text-center">
+    <img src="{% static 'theme/img/FreedomBox-logo-standard.png' %}"
+         alt="{{ box_name }}" width="640"/>
+  </p>
 
 {% endblock %}


### PR DESCRIPTION
- Add the FreedomBox image which is shown in firstboot page to the first setup
  page as well.
- Login button is removed to avoid confusion.
- Remove the check for `setup_helper.current_operation` so that the first setup
  page seamlessly transitions into the firstboot page.

The user experience will as follows:
1. A user sees the first setup page with the warning message to wait till it is
done.
2. The page automatically refreshes and the user will notice that the warning
message is gone and will proceed to click the "Start Setup" button which just
appeared.