### PR TITLE
Security: Unauthenticated API Endpoint Exposes Domain Information

### DIFF
--- a/plinth/modules/api/views.py
+++ b/plinth/modules/api/views.py
@@ -16,6 +16,8 @@ from plinth.modules import names
 
 def access_info(request: HttpRequest, **kwargs) -> HttpResponse:
     """API view to return a list of domains and types."""
+    if not request.user.is_authenticated:
+        return HttpResponse(status=401)
     domains = [{
         'domain': domain.name,
         'type': domain.domain_type.component_id


### PR DESCRIPTION
## Summary

Security: Unauthenticated API Endpoint Exposes Domain Information

## Problem

**Severity**: `High` | **File**: `plinth/modules/api/views.py:L17`

The access_info API view in plinth/modules/api/views.py returns a list of all registered domains and their types without requiring authentication. This exposes sensitive network configuration information to unauthenticated users.

## Solution

Add authentication check at the beginning of the access_info function. Only allow authenticated users to access this sensitive network information.

## Changes

- `plinth/modules/api/views.py` (modified)